### PR TITLE
Updated Syntax and docbook-xsl link in install.xq

### DIFF
--- a/install.xq
+++ b/install.xq
@@ -10,15 +10,15 @@ file:create-dir($C:TMP),
 
 (: all sources and their path/name where they shall end up :)
 let $deps := (
-  {
-    "url" : "http://sourceforge.net/projects/docbook/files/docbook-xsl-ns/1.78.1/docbook-xsl-ns-1.78.1.zip/download",
+  map {
+    "url" : "http://downloads.sourceforge.net/project/docbook/docbook-xsl-doc/1.79.1/docbook-xsl-doc-1.79.1.zip?r=&amp;ts=1456326295&amp;use_mirror=netix",
     "name" : "docbook-xsl"
   },
-  {
+  map {
     "url" : "http://archive.apache.org/dist/xmlgraphics/fop/binaries/fop-1.1-bin.zip",
     "name" : "fop"
   },
-  { (: original url: http://www.dbdoclet.org/archives/herold-6_1_0-188.zip :)
+  map { (: original url: http://www.dbdoclet.org/archives/herold-6_1_0-188.zip :)
     "url" : "http://files.basex.org/etc/herold-6.1.0-188.zip",
     "name" : "herold"
   }


### PR DESCRIPTION
Previously, the link was not working and the syntax was outdated. Updated the same.
